### PR TITLE
fix for items that stack to less than 64

### DIFF
--- a/src/main/java/io/github/mooy1/infinitylib/machines/MachineBlock.java
+++ b/src/main/java/io/github/mooy1/infinitylib/machines/MachineBlock.java
@@ -161,7 +161,7 @@ public final class MachineBlock extends AbstractMachineBlock {
             }
 
             //Add the Amount of FreeSpace that is Left in the Stack
-            freeSpace += 64 - itemStack.getAmount();
+            freeSpace += itemStack.getMaxStackSize() - itemStack.getAmount();
         }
 
         return freeSpace;

--- a/src/main/java/io/github/mooy1/infinitylib/machines/MachineBlock.java
+++ b/src/main/java/io/github/mooy1/infinitylib/machines/MachineBlock.java
@@ -151,7 +151,7 @@ public final class MachineBlock extends AbstractMachineBlock {
             //Get the Item in the Slot and Check if it's an Actual Item
             ItemStack itemStack = menu.getItemInSlot(slotNumber);
             if (itemStack == null || itemStack.getType() == Material.AIR) {
-                freeSpace += 64;
+                freeSpace += toWrap.getMaxStackSize();
                 continue;
             }
 


### PR DESCRIPTION
This is a hotfix for Mooy1/InfinityLib#6. The previous implementation of `getFreeSpace()` would return incorrect values if the max stack size for an item is less than 64 (e.g. Ender Pearls and Snowballs, as well as singular items like weapons and armor). This PR replaces the hardcoded max stack value of 64 in the check for free space in the stack with [ItemStack#getMaxStackSize()](https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/inventory/ItemStack.html#getMaxStackSize()).